### PR TITLE
Added support for dependencies used in ES6 computed object properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ function traverse(object, visitor) {
     child = object[key];
 
     if (typeof child === 'object' && child !== null) {
-      child.key = key;
+      if (typeof child.key === 'undefined') {
+        child.key = key;
+      }
       if (result = traverse(child, visitor)) {
         return result;
       }
@@ -120,7 +122,8 @@ function findUseage(variable, parsedCode) {
 
       // Do not traverse function body.
       return false;
-    } else if (object.type === 'Identifier' && object.name === variable &&
+    } else if (object.type === 'Identifier' &&
+        (object.name === variable || (object.key && object.key.name && object.key.name.indexof(variable) !== -1)) &&
         object.key !== 'property' && object.key !== 'id') {
       return object;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -192,6 +192,38 @@ describe('amdextract', function() {
         it('.unusedDependencies', function() { result.unusedDependencies.should.be.eql(['a']); });
         it('.optimizedContent', function() { should(output.optimizedContent).be.equal(optimizedContent); });
       });
+
+      describe('es6 computed properties postive match', function() {
+        var output = amdextract.parse(
+          "define('name', ['p1'], function(a) { var computed = {[a.const]: 'value'} })",
+          { removeUnusedDependencies: true }
+        );
+        var result = output.results[0];
+        it('.moduleId', function() { should(result.moduleId).equal('name'); });
+        it('.paths', function() { result.paths.should.be.eql(['p1']); });
+        it('.dependencies', function() { result.dependencies.should.be.eql(['a']); });
+        it('.unusedPaths', function() { result.unusedPaths.should.be.eql([]); });
+        it('.unusedDependencies', function() { result.unusedDependencies.should.be.eql([]); });
+        it('.optimizedContent', function() { should(output.optimizedContent).be.equal(
+          "define('name', ['p1'], function(a) { var computed = {[a.const]: 'value'} })"
+        ); });
+      })
+
+      describe('es6 computed properties negative match', function() {
+        var output = amdextract.parse(
+          "define('name', ['p1'], function(a) { var computed = {[b.const]: 'value'} })",
+          { removeUnusedDependencies: true }
+        );
+        var result = output.results[0];
+        it('.moduleId', function() { should(result.moduleId).equal('name'); });
+        it('.paths', function() { result.paths.should.be.eql(['p1']); });
+        it('.dependencies', function() { result.dependencies.should.be.eql(['a']); });
+        it('.unusedPaths', function() { result.unusedPaths.should.be.eql(['p1']); });
+        it('.unusedDependencies', function() { result.unusedDependencies.should.be.eql(['a']); });
+        it('.optimizedContent', function() { should(output.optimizedContent).be.equal(
+          "define('name', [], function() { var computed = {[b.const]: 'value'} })"
+        ); });
+      })
     });
   });
 });


### PR DESCRIPTION
Hey @mehdishojaei, I was using amdextract as part of grunt-amdcheck and noticed that I was getting some false positives for unused dependencies when I used the dependency in an ES6 computed object property. In my use case, we have an AppConstants dependency that holds a bunch of common strings, which can be used to create a computed object property name like this:

```javascript
var obj = {
    [AppConstants.CONST]: 'sample value'
}
```
This would result in grunt-amdcheck claiming that the AppConstants dependency was not being used. It seems like the issue was that when processing the computed property, the traverse function would do this:

```
first iteration...
-------
key --> 0
child --> Property {
  type: 'Property',
  key: Identifier { type: 'Identifier', name: 'AppConstants', range: [ 73, 85 ] },
  computed: true,
  value:
   Literal {
     type: 'Literal',
     value: 'sample value',
     raw: '\'sample value\'',
     range: [ 88, 102 ] },
  kind: 'init',
  method: false,
  shorthand: false,
  range: [ 72, 102 ] }

second iteration...
-------
child --> Property {
  type: 'Property',
  key: '0',
  computed: true,
  value:
   Literal {
     type: 'Literal',
     value: 'sample value',
     raw: '\'sample value\'',
     range: [ 88, 102 ] },
  kind: 'init',
  method: false,
  shorthand: false,
  range: [ 72, 102 ] }
```

So we lose the original identifier information `Identifier { type: 'Identifier', name: 'AppConstants', range: [ 73, 85 ] },` and the `key` gets overwritten with `'0'`.